### PR TITLE
fix: remove hard coded leaderboard url

### DIFF
--- a/embedded_plugins/Leader-Board.js
+++ b/embedded_plugins/Leader-Board.js
@@ -51,7 +51,7 @@ function formatNumber(num, decimalCount = 1) {
 }
 
 async function downloadLeaderboard() {
-  return fetch(`https://darkforest-leaderboard.altresearch.xyz/leaderboard`)
+  return fetch(`${process.env.AL_SERVER_URL}/leaderboard`)
     .then(response => response.json())
 }
 


### PR DESCRIPTION
Revert hard-coded URL from last community round